### PR TITLE
Fix query parameter handling. Was not passed to OAuth2 object.

### DIFF
--- a/lib/gini-api/client.rb
+++ b/lib/gini-api/client.rb
@@ -283,8 +283,8 @@ module Gini
       # @param [String] file location of document to be uploaded
       #
       # @return [Faraday::Response] Response object from upload
+      #
       def upload_document(file)
-        # Create upload connection
         @upload_connection ||= Faraday.new(url: @api_uri) do |builder|
           builder.use(Faraday::Request::Multipart)
           builder.use(Faraday::Request::UrlEncoded)


### PR DESCRIPTION
Howdy @layflags,

what do you think? By now the query parameters where ignored and never forwarded to the api. 
