### PR TITLE
Support incubator extractions. Closes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,23 @@ doc.extractions.undefinedLabel
 # => nil
 ```
 
+#### Incubator
+
+The incubator Gini API is unstable and subject of change. It allows early access to immature features which are still in research or under development. Please refer to the official API documentation for further details.
+
+```ruby
+doc.extractions(incubator=true).amountLiters
+# => {:amountLiters=>{:entity=>"volume", :value=>"25.34:l", :box=>{:top=>1774.0, :left=>674.0, :width=>376.0, :height=>48.0, :page=>1}}
+doc.extractions(incubator=true)[:amountLiters]
+# => "25.34:l"
+```
+
 ### Submitting feedback
 
 ```ruby
 doc.extractions.bic = 'XXXXXXXX'
 # => 'XXXXXXXX'
-doc.extractions.bic = { value: 'XXXXXXXX', :box=>{:top=>2176.0, :left=>2000.0, :width=>173.0, :height=>50.0, :page=>1 }
+doc.extractions.bic = { value: 'XXXXXXXX', :box=>{ :top=>2176.0, :left=>2000.0, :width=>173.0, :height=>50.0, :page=>1 } }
 # => { value: 'XXXXXXXX', box: { top: 2176.0, left: 2000.0, width: 173.0, height: 50.0, page: 1 }
 doc.extractions.unknownLabel = 'XXXXXXXX'
 # => raises Gini::Api::DocumentError

--- a/lib/gini-api/client.rb
+++ b/lib/gini-api/client.rb
@@ -79,6 +79,9 @@ module Gini
         OAuth2::Response.register_parser(:gini_xml, [version_header(:xml)[:accept]]) do |body|
           MultiXml.parse(body) rescue body
         end
+        OAuth2::Response.register_parser(:gini_incubator, [version_header(:json, :incubator)[:accept]]) do |body|
+          MultiJson.load(body, symbolize_keys: true) rescue body
+        end
       end
 
       # Acquire OAuth2 token and popolate @oauth (instance of Gini::Api::OAuth.new)
@@ -108,11 +111,12 @@ module Gini
       # Version accept header based on @api_version
       #
       # @param [Symbol, String] type Expected response type (:xml, :json)
+      # @param [Symbol, String] version API version (:v1, :incubator)
       #
       # @return [Hash] Return accept header or empty hash
       #
-      def version_header(type = @api_type)
-        { accept: "application/vnd.gini.#{@api_version}+#{type}" }
+      def version_header(type = @api_type, version = @api_version)
+        { accept: "application/vnd.gini.#{version}+#{type}" }
       end
 
       # Request wrapper that sets URI and accept header

--- a/lib/gini-api/document.rb
+++ b/lib/gini-api/document.rb
@@ -101,10 +101,12 @@ module Gini
 
       # Initialize extractions from @_links and return Gini::Api::Extractions object
       #
+      # @param [Boolean] incubator Return experimental extractions
+      #
       # @return [Gini::Api::Document::Extractions] Return Gini::Api::Document::Extractions object for uploaded document
       #
-      def extractions
-        @extractions ||= Gini::Api::Document::Extractions.new(@api, @_links[:extractions])
+      def extractions(incubator = false)
+        @extractions ||= Gini::Api::Document::Extractions.new(@api, @_links[:extractions], incubator)
       end
 
       # Initialize layout from @_links[:layout] and return Gini::Api::Layout object

--- a/spec/gini-api/client_spec.rb
+++ b/spec/gini-api/client_spec.rb
@@ -58,6 +58,11 @@ describe Gini::Api::Client do
         include(:gini_xml)
     end
 
+    it do
+      expect(OAuth2::Response::PARSERS.keys).to \
+        include(:gini_incubator)
+    end
+
   end
 
   describe '#login' do
@@ -136,6 +141,15 @@ describe Gini::Api::Client do
       it 'returns accept header with xml type' do
         expect(api.version_header(:xml)).to \
           eql({ accept: 'application/vnd.gini.v1+xml' })
+      end
+
+    end
+
+    context 'with incubator' do
+
+      it 'returns accept header with incubator version' do
+        expect(api.version_header(:json, :incubator)).to \
+          eql({ accept: 'application/vnd.gini.incubator+json' })
       end
 
     end
@@ -219,6 +233,24 @@ describe Gini::Api::Client do
             '/dummy',
             type: 'xml'
           ).parsed).to be_a Hash
+        end
+
+      end
+
+      context 'return JSON on incubator request' do
+
+        let(:header) { 'application/vnd.gini.incubator+json' }
+        let(:body)   {
+          {
+            a: 1,
+            b: 2
+          }.to_json
+        }
+
+        it do
+          expect(api.token).to \
+            receive(:get).and_return(OAuth2::Response.new(response))
+          expect(api.request(:get, '/dummy').parsed).to be_a Hash
         end
 
       end


### PR DESCRIPTION
Support incubator extractions by passing incubator=true to extractions method. Please refer to the official Gini API documentation for available extractions and requirements.