### PR TITLE
Fixes #20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gini-api (0.9.10)
+    gini-api (0.9.11)
       logger
       oauth2
 
@@ -47,7 +47,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.2)
-    jwt (1.2.0)
+    jwt (1.5.0)
     listen (2.8.5)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -73,7 +73,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.0)
+    rack (1.6.1)
     rake (10.4.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)

--- a/README.md
+++ b/README.md
@@ -157,14 +157,23 @@ doc.extractions.undefinedLabel
 # => nil
 ```
 
+By default extractions are only fetched once and later requests return the cached values. Setting refresh=true will invalidate the cache and query the API directly.
+
+```ruby
+d.extractions(refresh: true)[:amountToPay]
+# => "10.00:EUR"
+doc.extractions(refresh: true).raw
+# => {:extractions=>{...
+```
+
 #### Incubator
 
 The incubator Gini API is unstable and subject of change. It allows early access to immature features which are still in research or under development. Please refer to the official API documentation for further details.
 
 ```ruby
-doc.extractions(incubator=true).amountLiters
+doc.extractions(incubator: true).amountLiters
 # => {:amountLiters=>{:entity=>"volume", :value=>"25.34:l", :box=>{:top=>1774.0, :left=>674.0, :width=>376.0, :height=>48.0, :page=>1}}
-doc.extractions(incubator=true)[:amountLiters]
+doc.extractions(incubator: true)[:amountLiters]
 # => "25.34:l"
 ```
 

--- a/lib/gini-api/document.rb
+++ b/lib/gini-api/document.rb
@@ -101,12 +101,19 @@ module Gini
 
       # Initialize extractions from @_links and return Gini::Api::Extractions object
       #
-      # @param [Boolean] incubator Return experimental extractions
+      # @param [Hash]    options  Options
+      # @option options [Boolean] :refresh Invalidate extractions cache
+      # @option options [Boolean] :incubator Return experimental extractions
       #
       # @return [Gini::Api::Document::Extractions] Return Gini::Api::Document::Extractions object for uploaded document
       #
-      def extractions(incubator = false)
-        @extractions ||= Gini::Api::Document::Extractions.new(@api, @_links[:extractions], incubator)
+      def extractions(options = {})
+        opts = { refresh: false, incubator: false }.merge(options)
+        if opts[:refresh] or @extractions.nil?
+          @extractions = Gini::Api::Document::Extractions.new(@api, @_links[:extractions], opts[:incubator])
+        else
+          @extractions
+        end
       end
 
       # Initialize layout from @_links[:layout] and return Gini::Api::Layout object

--- a/lib/gini-api/version.rb
+++ b/lib/gini-api/version.rb
@@ -1,6 +1,6 @@
 module Gini
   module Api
     # Package version
-    VERSION = '0.9.10'
+    VERSION = '0.9.11'
   end
 end

--- a/spec/gini-api/document_spec.rb
+++ b/spec/gini-api/document_spec.rb
@@ -237,12 +237,53 @@ describe Gini::Api::Document do
       })
     end
 
-    it do
-      allow(api.token).to receive(:get).with(
-        "#{location}/extractions",
-        { headers: { accept: header } }
-      ).and_return(OAuth2::Response.new(ex_response))
-      expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+    context 'with default options' do
+
+      it do
+        expect(api.token).to receive(:get).with(
+          "#{location}/extractions",
+          { headers: { accept: header } }
+        ).and_return(OAuth2::Response.new(ex_response))
+        expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+      end
+
+      it 'returns the same data every time' do
+        expect(api.token).to receive(:get).once.with(
+          "#{location}/extractions",
+          { headers: { accept: header } }
+        ).and_return(OAuth2::Response.new(ex_response))
+        expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+        expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+        expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+      end
+
+    end
+
+    context 'with refresh == true' do
+
+      it do
+        expect(api.token).to receive(:get).twice.with(
+          "#{location}/extractions",
+          { headers: { accept: header } }
+        ).and_return(OAuth2::Response.new(ex_response))
+        expect(document.extractions).to be_a(Gini::Api::Document::Extractions)
+        expect(document.extractions(refresh: true)).to be_a(Gini::Api::Document::Extractions)
+      end
+
+    end
+
+    context 'with incubator == true' do
+
+      let(:incubator_header) { 'application/vnd.gini.incubator+json' }
+
+      it do
+        expect(api.token).to receive(:get).with(
+          "#{location}/extractions",
+          { headers: { accept: incubator_header } }
+        ).and_return(OAuth2::Response.new(ex_response))
+        expect(document.extractions(incubator: true)).to be_a(Gini::Api::Document::Extractions)
+      end
+
     end
 
   end


### PR DESCRIPTION
Method extractions takes options hash.
refresh: true will invalidate the cache
incubator: true returns incubator extractions
Updated README
Version bump to 0.9.11
